### PR TITLE
#26 企業ログイン時に学生プロフィールページが閲覧できないエラーを修正

### DIFF
--- a/app/views/students/_tags.html.erb
+++ b/app/views/students/_tags.html.erb
@@ -1,0 +1,19 @@
+<div class="tags">
+  <h3>登録タグ</h3>
+    <% if @student == current_user.student %>
+      <div class="to_edit"><%= link_to "タグを編集する", edit_user_path %></div>
+    <% end %>
+    <!-- スキルタグ -->
+    <div>
+      <% if @student.skill_list.empty? && @student.personality_list.empty? %>
+        <p>タグは登録されていません。</p>
+      <% end %>
+      <% @student.skill_list.each do |skill| %>
+        <div class="tag skill"><%= skill %></div>
+      <% end %>
+      <!-- パーソナリティタグ -->
+      <% @student.personality_list.each do |personality| %>
+        <div class="tag personality"><%= personality %></div>
+      <% end %>
+    </div>
+  </div>

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -13,7 +13,7 @@
               <%= render partial: "users/student", locals: {student: @student} %>
           </ul>
         </div>
-        <%= render partial: "users/tags", locals: {student: @student} %>
+        <%= render partial: "tags", locals: {student: @student} %>
       </div>
     </div>
     <div class="col-sm-9">

--- a/app/views/users/_tags.html.erb
+++ b/app/views/users/_tags.html.erb
@@ -27,7 +27,7 @@
     <% if @client == current_user.client %>
     <% end %>
     <!-- スキルタグ -->
-    <% if @client.student.skill_list.empty? && @client.personality_list.empty? %>
+    <% if @client.skill_list.empty? && @client.personality_list.empty? %>
       <p>タグは登録されていません。</p>
     <% end %>
     <% @client.skill_list.each do |skill| %>
@@ -46,7 +46,7 @@
   <div class="tags">
     <h3>企業風土</h3>
     <!-- 企業風土タグ -->
-    <% if @student.system_list.empty? %>
+    <% if @client.system_list.empty? %>
       <p>タグは登録されていません。</p>
     <% end %>
     <% @client.system_list.each do |system| %>


### PR DESCRIPTION
# 概要
企業ログイン時、学生のプロフィールを閲覧しようとするとエラーが発生していた。

# 原因
タグ表示部分のパーシャルがログイン時の属性に依存していたため、クライアントログイン時に自分のタグを表示しようとしていた。その際に参照エラーが発生していたもよう。

# 対応
適切にパーシャルを切り分けたところ、正常に表示されるようになりました。