### PR TITLE
不要なログイン行を削除

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -12,7 +12,6 @@ class ProductsController < ApplicationController
   def create
     @product = Product.new(product_params)
     if @product.save
-      log_in @product
       flash[:success] = "作品登録を行いました。"
       redirect_to @product
     else


### PR DESCRIPTION
# 概要
就プレ作品登録時に別にユーザにログインしてしまっていたバグがありました。

# 原因
product#actionにログインメソッドが書かれていたため、そこが原因かと思われます。

# 対応
login行を削除して対応しました。