### PR TITLE
モバイル向けマップページのレイアウト調整

### DIFF
--- a/app/assets/stylesheets/rooms.scss
+++ b/app/assets/stylesheets/rooms.scss
@@ -18,11 +18,12 @@
     }
     li {
       display: inline-block;
+      margin: 0 !important;
       width: 60px;
       height: 40px;
       font-size: 12px;
       letter-spacing: normal;
-      vertical-align: top;
+      vertical-align: middle;
     }
   }
   .exist-box {
@@ -63,5 +64,24 @@
   }
   .exit {
     margin-left: 900px;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  #room {
+    .map {
+      width: 1000px;
+      li {
+        font-size: 8px !important;
+        width: 40px;
+        height: 30px;
+        .code {
+          line-height: 10px;
+        }
+        .student {
+          letter-spacing: -0.8px;
+        }
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/rooms.scss
+++ b/app/assets/stylesheets/rooms.scss
@@ -83,5 +83,11 @@
         }
       }
     }
+    .enter {
+      margin-left: 20px;
+    }
+    .exit {
+      margin-left: 510px;
+    }
   }
 }

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -19,7 +19,7 @@
                   </div>
                   <div class="student">
                     <% if student %>
-                      <%= link_to student.user.name, student%>
+                      <%= link_to student.user.name.gsub(" ", ""), student%>
                     <% end %>
                   </div>
                 <% end %>

--- a/app/views/users/_tags.html.erb
+++ b/app/views/users/_tags.html.erb
@@ -30,17 +30,19 @@
     <% if @client.skill_list.empty? && @client.personality_list.empty? %>
       <p>タグは登録されていません。</p>
     <% end %>
-    <% @client.skill_list.each do |skill| %>
-      <div class="tag skill">
-        <%= link_to skill, :controller => "students", :action => "index", q: {skills_name_cont: skill} %>
-      </div>
-    <% end %>
-    <!-- 企業風土タグ -->
-    <% @client.personality_list.each do |personality| %>
-      <div class="tag personality">
-        <%= link_to personality, :controller => "students", :action => "index", q: {pertonalities_name_cont: personality} %>
-      </div>
-    <% end %>
+    <div>
+      <% @client.skill_list.each do |skill| %>
+        <div class="tag skill">
+          <%= link_to skill, :controller => "students", :action => "index", q: {skills_name_cont: skill} %>
+        </div>
+      <% end %>
+      <!-- 企業風土タグ -->
+      <% @client.personality_list.each do |personality| %>
+        <div class="tag personality">
+          <%= link_to personality, :controller => "students", :action => "index", q: {pertonalities_name_cont: personality} %>
+        </div>
+      <% end %>
+    </div>
   </div>
 
   <div class="tags">
@@ -49,11 +51,13 @@
     <% if @client.system_list.empty? %>
       <p>タグは登録されていません。</p>
     <% end %>
-    <% @client.system_list.each do |system| %>
-      <div class="tag system">
-        <%= system %>
-      </div>
-    <% end %>
+    </div>
+      <% @client.system_list.each do |system| %>
+        <div class="tag system">
+          <%= system %>
+        </div>
+      <% end %>
+    </div>
   </div>
   <div class="to_edit"><%= link_to "タグを編集する", edit_user_path %></div>
 <% end %>


### PR DESCRIPTION
# 概要
携帯端末でマップを表示した際に席が隣にならないなどのレイアウト崩れがあったため修正しました。

# 機能
- [x] 座席を隣接して表示
- [x] 携帯端末の際は座席を小さくして表示
- [x] 名前に含まれているスペースを削除して表示
- [x] 出入り口の位置を修正