### PR TITLE
学生のハイライト機能を追加

### DIFF
--- a/app/assets/stylesheets/rooms.scss
+++ b/app/assets/stylesheets/rooms.scss
@@ -44,6 +44,19 @@
     text-align: center;
     background-color: #fff;
   }
+  .special.code {
+    background-color: #1d4293;
+  }
+  .special.student {
+    background-color: #44aeea;
+    font-weight: bold;
+    a:link {
+      color: #fff;
+    }
+    a:visited {
+      color: #fff
+    }
+  }
   .doorway {
     font-size: 18px;
     width: 1500px;

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -14,14 +14,25 @@
                 <% if pos_info[:exhibit_code] == "none" %>
                 <% else %>
                   <% student = Student.find_by(exhibit_code: pos_info[:exhibit_code]) %>
-                  <div class="code">
-                    <%= pos_info[:exhibit_code] %>
-                  </div>
-                  <div class="student">
-                    <% if student %>
-                      <%= link_to student.user.name.gsub(" ", ""), student%>
-                    <% end %>
-                  </div>
+                  <% if student && student.exhibit_code == params[:exhibit_code] %>
+                    <div class="code special">
+                      <%= pos_info[:exhibit_code] %>
+                    </div>
+                    <div class="student special">
+                      <% if student %>
+                        <%= link_to student.user.name.gsub(" ", ""), student%>
+                      <% end %>
+                    </div>
+                  <%else %>
+                    <div class="code">
+                      <%= pos_info[:exhibit_code] %>
+                    </div>
+                    <div class="student">
+                      <% if student %>
+                        <%= link_to student.user.name.gsub(" ", ""), student%>
+                      <% end %>
+                    </div>
+                  <% end %>
                 <% end %>
               </li>
             <% else %>

--- a/app/views/users/_student.html.erb
+++ b/app/views/users/_student.html.erb
@@ -3,6 +3,9 @@
 <li>学籍番号： <%= @student.s_code %></li>
 <li>出席番号： <%= @student.s_no %></li>
 <% if client? %>
+  <div class="navi">
+    <%= link_to "場所を確認する", "/rooms/31?exhibit_code=#{@student.exhibit_code}" %>
+  </div>
   <div class="favorite">
     <% unless @favorite %>
       <%= link_to "お気に入り登録する", add_student_path(student), method: :post %>


### PR DESCRIPTION
# 概要
#37 
学生ページからマップページに飛んだ際に場所をわかりやすくする。

# 機能
- [x] 学生ページからマップページに飛ぶ際出展コードを付与
- [x] 学生の座席のハイライト